### PR TITLE
Declared global variables treated as undefined

### DIFF
--- a/test/contextify.js
+++ b/test/contextify.js
@@ -58,8 +58,12 @@ exports['basic tests'] = {
     'test for "undefined" variables' : function (test) {
         var sandbox = { };
         Contextify(sandbox);
-        sandbox.run("var y; _y = y");
+        // In JavaScript a declared variable is set to 'undefined'.
+        sandbox.run("var y; (function() { var _y ; y = _y })()");
         test.equal(sandbox._y, undefined);
+        // This should apply to top-level variables (global properties).
+        sandbox.run("var z; _z = z");
+        test.equal(sandbox._z, undefined);
         test.done();
     },
 


### PR DESCRIPTION
In JavaScript, this results in an `ReferenceError: y is not defined`:

```
x = y
```

OTOH a variable declared with no value is set to `undefined`, and so this sets x to `undefined`:

```
var y
x = y
```

This pull requests provides two tests, one with a sandbox property (`x`) set to `undefined` and one with a global variable (`z`) declared as `undefined`.

This seems to fix the first test, by returning the sandbox property if defined, regardless of value:

```
Local<Value> rv = sandbox->Get(property);
if (sandbox->HasRealNamedProperty(property))
    return scope.Close(rv);

// Next, check the global object (things like Object, Array, etc).
// This needs to call GetRealNamedProperty or else we'll get stuck in
// an infinite loop here.
rv = info->global->GetRealNamedProperty(property);
```

I am not sure if this is correct, or how to go about fixing the second test.
