### PR TITLE
Can't use global.eval as a function

### DIFF
--- a/test/contextify.js
+++ b/test/contextify.js
@@ -372,10 +372,12 @@ exports['test eval'] = {
         var sandbox = Contextify();
         sandbox.run('e = eval ; e("test1 = 1")');
         test.equal(sandbox.test1, 1);
-        sandbox.run('t = 1 ; (function() { var t = 2; test2 = eval("t") })()');
+        sandbox.run('var t = 1 ; (function() { var t = 2; test2 = eval("t") })()');
         test.equal(sandbox.test2, 2);
         sandbox.run('t = 1 ; (function() { var t = 2; e = eval; test3 = e("t") })()');
         test.equal(sandbox.test3, 1);
+        sandbox.run('var t = 1 ; global = this; (function() { var t = 2; e = eval; test4 = global.eval.call(global, "t") })()');
+        test.equal(sandbox.test4, 1);
         test.done();
     }
 };


### PR DESCRIPTION
This does the right thing:

```
eval("foo")
```

But this fails, complaining `The "this" object passed to eval must be the global object from which eval originated`:

```
e = eval;
e("too")
```

This fails too (jQuery uses in some place):

```
window.eval(window, "foo")
```

Any idea what's going on?
