### PR TITLE
Allow precompiling scripts

### DIFF
--- a/lib/contextify.js
+++ b/lib/contextify.js
@@ -1,6 +1,8 @@
-var ContextifyContext = require('bindings')('contextify').ContextifyContext;
+var binding = require('bindings')('contextify');
+var ContextifyContext = binding.ContextifyContext;
+var ContextifyScript = binding.ContextifyScript;
 
-module.exports = function Contextify (sandbox) {
+function Contextify (sandbox) {
     if (typeof sandbox != 'object') {
         sandbox = {};
     }
@@ -28,3 +30,19 @@ module.exports = function Contextify (sandbox) {
     }
     return sandbox;
 }
+
+Contextify.createContext = function (sandbox) {
+    if (typeof sandbox != 'object') {
+        sandbox = {};
+    }
+    return new ContextifyContext(sandbox);
+};
+
+Contextify.createScript = function (code, filename) {
+    if (typeof code != 'string') {
+        throw new TypeError('Code argument is required');
+    }
+    return new ContextifyScript(code, filename);
+};
+
+module.exports = Contextify;


### PR DESCRIPTION
Similar to the `vm` API in node, this allows you to create a Contextify context like this:

``` javascript
var sandbox = {};
var context = Contextify.createContext(sandbox);
```

Unlike `Contextify()`, createContext does not augment the sandbox with `run`, `getGlobal` and `dispose`.

This also adds `Contextify.createScript`, similar to `vm.createScript`, which will pre-compile code and let you run it in a Contextify context later. This can have huge performance benefits, e.g. a web server that runs each request in a separate context.

``` javascript
var sandbox = {};
var context = Contextify.createContext(sandbox);
var script = Contextify.createScript('var x = 1');
script.runInContext(context);
// sandbox.x === 1
```
