### PR TITLE
Fix segfaults with node>=0.9.6 due to changes in node ObjectWrap

### DIFF
--- a/src/contextify.cc
+++ b/src/contextify.cc
@@ -1,4 +1,5 @@
 #include "node.h"
+#include "node_version.h"
 #include <string>
 using namespace v8;
 using namespace node;
@@ -48,7 +49,11 @@ public:
     Local<Object> createDataWrapper () {
         HandleScope scope;
         Local<Object> wrapper = dataWrapperCtor->NewInstance();
+#if NODE_MAJOR_VERSION > 0 || NODE_MINOR_VERSION > 9 || (NODE_MINOR_VERSION >= 9 && NODE_PATCH_VERSION >= 6)
+        wrapper->SetAlignedPointerInInternalField(0, this);
+#else
         wrapper->SetPointerInInternalField(0, this);
+#endif
         return scope.Close(wrapper);
     }
 


### PR DESCRIPTION
This fixes segfaults when using contextify with node>=0.9.6

node::ObjectWrap::Wrap and Unwrap in node>=0.9.6 uses
Set/GetAlignedPointerInInternalField instead of
Set/GetPointerInInternalField.
