### PR TITLE
Remove -fno-tree-vrp cflag so that clang can be used to compile

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -3,7 +3,8 @@
     {
       'target_name': 'contextify',
       'include_dirs': ["<!(node -e \"require('nan')\")"],
-      'sources': [ 'src/contextify.cc' ]
+      'sources': [ 'src/contextify.cc' ],
+      'cflags!': ['-fno-tree-vrp'],
     }
   ]
 }


### PR DESCRIPTION
`node-gyp` fails to build this project when `CXX=clang++` because `-fno-tree-vrp` is an unknown argument. To compile with both `g++` and `clang++`, I disabled the flag.

```
$ node-gyp build
gyp info it worked if it ends with ok
gyp info using node-gyp@0.13.0
gyp info using node@0.10.25 | linux | x64
gyp info spawn make
gyp info spawn args [ 'BUILDTYPE=Release', '-C', 'build' ]
make: Entering directory `/srv/nix_repo/workspace/projects/javascript/contextify/build'
  CXX(target) Release/obj.target/contextify/src/contextify.o
clang: error: unknown argument: '-fno-tree-vrp'
make: *** [Release/obj.target/contextify/src/contextify.o] Error 1
make: Leaving directory `/srv/nix_repo/workspace/projects/javascript/contextify/build'
gyp ERR! build error
gyp ERR! stack Error: `make` failed with exit code: 2
gyp ERR! stack     at ChildProcess.onExit (/usr/lib/node_modules/node-gyp/lib/build.js:267:23)
gyp ERR! stack     at ChildProcess.EventEmitter.emit (events.js:98:17)
gyp ERR! stack     at Process.ChildProcess._handle.onexit (child_process.js:797:12)
gyp ERR! System Linux 3.13.0-24-generic
gyp ERR! command "node" "/usr/bin/node-gyp" "build"
gyp ERR! cwd /srv/nix_repo/workspace/projects/javascript/contextify
gyp ERR! node -v v0.10.25
gyp ERR! node-gyp -v v0.13.0
gyp ERR! not ok
```
