### PR TITLE
Notify heap on context disposal

### DIFF
--- a/src/contextify.cc
+++ b/src/contextify.cc
@@ -27,6 +27,11 @@ public:
         NanDisposePersistent(context);
         NanDisposePersistent(proxyGlobal);
         NanDisposePersistent(sandbox);
+
+        // Provide a GC hint that the context has gone away. Without this call it
+        // does not seem that the collector will touch the context until under extreme
+        // stress.
+        v8::V8::ContextDisposedNotification();
     }
 
     // We override ObjectWrap::Wrap so that we can create our context after


### PR DESCRIPTION
Resolves issues where the global context buffers are retained until extreme memory stress occurs.
