### PR TITLE
fix segfault in GlobalPropertyGetter() (closes #89)

### DIFF
--- a/src/contextify.cc
+++ b/src/contextify.cc
@@ -5,10 +5,7 @@
 using namespace v8;
 using namespace node;
 
-// For some reason this needs to be out of the object or node won't load the
-// library.
-static Persistent<FunctionTemplate> dataWrapperTmpl;
-static Persistent<Function>         dataWrapperCtor;
+class ContextWrap;
 
 class ContextifyContext : public ObjectWrap {
 public:
@@ -38,47 +35,10 @@ public:
     // we have a reference to our "host" JavaScript object.  If we try to use
     // handle_ in the ContextifyContext constructor, it will be empty since it's
     // set in ObjectWrap::Wrap.
-    inline void Wrap(Handle<Object> handle) {
-        ObjectWrap::Wrap(handle);
-        Local<Context> lcontext = createV8Context();
-        NanAssignPersistent(context, lcontext);
-        NanAssignPersistent(proxyGlobal, lcontext->Global());
-    }
-
-    // This is an object that just keeps an internal pointer to this
-    // ContextifyContext.  It's passed to the NamedPropertyHandler.  If we
-    // pass the main JavaScript context object we're embedded in, then the
-    // NamedPropertyHandler will store a reference to it forever and keep it
-    // from getting gc'd.
-    Local<Object> createDataWrapper () {
-        NanEscapableScope();
-        Local<Object> wrapper = NanNew(dataWrapperCtor)->NewInstance();
-        NanSetInternalFieldPointer(wrapper, 0, this);
-        return NanEscapeScope(wrapper);
-    }
-
-    inline Local<Context> createV8Context() {
-        Local<FunctionTemplate> ftmpl = NanNew<FunctionTemplate>();
-        ftmpl->SetHiddenPrototype(true);
-        ftmpl->SetClassName(NanNew(sandbox)->GetConstructorName());
-        Local<ObjectTemplate> otmpl = ftmpl->InstanceTemplate();
-        otmpl->SetNamedPropertyHandler(GlobalPropertyGetter,
-                                       GlobalPropertySetter,
-                                       GlobalPropertyQuery,
-                                       GlobalPropertyDeleter,
-                                       GlobalPropertyEnumerator,
-                                       createDataWrapper());
-        otmpl->SetAccessCheckCallbacks(GlobalPropertyNamedAccessCheck,
-                                       GlobalPropertyIndexedAccessCheck);
-        return NanNewContextHandle(NULL, otmpl);
-    }
+    void Wrap(Handle<Object> handle);
 
     static void Init(Handle<Object> target) {
         NanScope();
-        Local<FunctionTemplate> tmpl = NanNew<FunctionTemplate>();
-        tmpl->InstanceTemplate()->SetInternalFieldCount(1);
-        NanAssignPersistent(dataWrapperTmpl, tmpl);
-        NanAssignPersistent(dataWrapperCtor, tmpl->GetFunction());
 
         Local<FunctionTemplate> ljsTmpl = NanNew<FunctionTemplate>(New);
         ljsTmpl->InstanceTemplate()->SetInternalFieldCount(1);
@@ -156,6 +116,54 @@ public:
         ContextifyContext* ctx = ObjectWrap::Unwrap<ContextifyContext>(args.This());
         NanReturnValue(ctx->proxyGlobal);
     }
+};
+
+// This is an object that just keeps an internal pointer to this
+// ContextifyContext.  It's passed to the NamedPropertyHandler.  If we
+// pass the main JavaScript context object we're embedded in, then the
+// NamedPropertyHandler will store a reference to it forever and keep it
+// from getting gc'd.
+class ContextWrap : public ObjectWrap {
+public:
+    static void Init(void) {
+        NanScope();
+        Local<FunctionTemplate> tmpl = NanNew<FunctionTemplate>();
+        tmpl->InstanceTemplate()->SetInternalFieldCount(1);
+        NanAssignPersistent(functionTemplate, tmpl);
+        NanAssignPersistent(constructor, tmpl->GetFunction());
+    }
+
+    static Local<Context> createV8Context(Handle<Object> jsContextify) {
+        NanEscapableScope();
+        Local<Object> wrapper = constructor->NewInstance();
+
+        ContextWrap *contextWrapper = new ContextWrap();
+        contextWrapper->Wrap(wrapper);
+
+        Local<Object> obj = NanNew(jsContextify);
+        NanMakeWeakPersistent(obj, contextWrapper, &weakCallback);
+        contextWrapper->ctx = ObjectWrap::Unwrap<ContextifyContext>(jsContextify);
+
+        Local<FunctionTemplate> ftmpl = NanNew<FunctionTemplate>();
+        ftmpl->SetHiddenPrototype(true);
+        ftmpl->SetClassName(NanNew(contextWrapper->ctx->sandbox)->GetConstructorName());
+        Local<ObjectTemplate> otmpl = ftmpl->InstanceTemplate();
+        otmpl->SetNamedPropertyHandler(GlobalPropertyGetter,
+                                       GlobalPropertySetter,
+                                       GlobalPropertyQuery,
+                                       GlobalPropertyDeleter,
+                                       GlobalPropertyEnumerator,
+                                       wrapper);
+        otmpl->SetAccessCheckCallbacks(GlobalPropertyNamedAccessCheck,
+                                       GlobalPropertyIndexedAccessCheck);
+        return NanEscapeScope(NanNewContextHandle(NULL, otmpl));
+    }
+
+private:
+    ContextWrap() :ctx(NULL) {}
+
+    ~ContextWrap() {
+    }
 
     static bool GlobalPropertyNamedAccessCheck(Local<Object> host,
                                                Local<Value>  key,
@@ -174,7 +182,9 @@ public:
     static NAN_PROPERTY_GETTER(GlobalPropertyGetter) {
         NanScope();
         Local<Object> data = args.Data()->ToObject();
-        ContextifyContext* ctx = ObjectWrap::Unwrap<ContextifyContext>(data);
+        ContextifyContext* ctx = ObjectWrap::Unwrap<ContextWrap>(data)->ctx;
+        if (!ctx)
+            NanReturnUndefined();
         Local<Value> rv = NanNew(ctx->sandbox)->GetRealNamedProperty(property);
         if (rv.IsEmpty()) {
             rv = NanNew(ctx->proxyGlobal)->GetRealNamedProperty(property);
@@ -185,7 +195,9 @@ public:
     static NAN_PROPERTY_SETTER(GlobalPropertySetter) {
         NanScope();
         Local<Object> data = args.Data()->ToObject();
-        ContextifyContext* ctx = ObjectWrap::Unwrap<ContextifyContext>(data);
+        ContextifyContext* ctx = ObjectWrap::Unwrap<ContextWrap>(data)->ctx;
+        if (!ctx)
+            NanReturnUndefined();
         NanNew(ctx->sandbox)->Set(property, value);
         NanReturnValue(value);
     }
@@ -193,7 +205,9 @@ public:
     static NAN_PROPERTY_QUERY(GlobalPropertyQuery) {
         NanScope();
         Local<Object> data = args.Data()->ToObject();
-        ContextifyContext* ctx = ObjectWrap::Unwrap<ContextifyContext>(data);
+        ContextifyContext* ctx = ObjectWrap::Unwrap<ContextWrap>(data)->ctx;
+        if (!ctx)
+            NanReturnValue(NanNew<Integer>(None));
         if (!NanNew(ctx->sandbox)->GetRealNamedProperty(property).IsEmpty() ||
             !NanNew(ctx->proxyGlobal)->GetRealNamedProperty(property).IsEmpty()) {
             NanReturnValue(NanNew<Integer>(None));
@@ -205,7 +219,9 @@ public:
     static NAN_PROPERTY_DELETER(GlobalPropertyDeleter) {
         NanScope();
         Local<Object> data = args.Data()->ToObject();
-        ContextifyContext* ctx = ObjectWrap::Unwrap<ContextifyContext>(data);
+        ContextifyContext* ctx = ObjectWrap::Unwrap<ContextWrap>(data)->ctx;
+        if (!ctx)
+            NanReturnValue(NanNew<Boolean>(false));
         bool success = NanNew(ctx->sandbox)->Delete(property);
         NanReturnValue(NanNew<Boolean>(success));
     }
@@ -213,10 +229,33 @@ public:
     static NAN_PROPERTY_ENUMERATOR(GlobalPropertyEnumerator) {
         NanScope();
         Local<Object> data = args.Data()->ToObject();
-        ContextifyContext* ctx = ObjectWrap::Unwrap<ContextifyContext>(data);
+        ContextifyContext* ctx = ObjectWrap::Unwrap<ContextWrap>(data)->ctx;
+        if (!ctx) {
+            Local<Array> blank = Array::New(0);
+            NanReturnValue(blank);
+        }
         NanReturnValue(NanNew(ctx->sandbox)->GetPropertyNames());
     }
+
+    NAN_WEAK_CALLBACK(weakCallback) {
+        ContextWrap *self = data.GetParameter();
+        self->ctx = NULL;
+    }
+
+    static Persistent<FunctionTemplate> functionTemplate;
+    static Persistent<Function>         constructor;
+    ContextifyContext                   *ctx;
 };
+
+Persistent<FunctionTemplate> ContextWrap::functionTemplate;
+Persistent<Function>         ContextWrap::constructor;
+
+void ContextifyContext::Wrap(Handle<Object> handle) {
+    ObjectWrap::Wrap(handle);
+    Local<Context> lcontext = ContextWrap::createV8Context(handle);
+    NanAssignPersistent(context, lcontext);
+    NanAssignPersistent(proxyGlobal, lcontext->Global());
+}
 
 class ContextifyScript : public ObjectWrap {
 public:
@@ -309,6 +348,7 @@ extern "C" {
     static void init(Handle<Object> target) {
         ContextifyContext::Init(target);
         ContextifyScript::Init(target);
+        ContextWrap::Init();
     }
     NODE_MODULE(contextify, init);
 };


### PR DESCRIPTION
We operated on `wrapper` (the result of `createDataWrapper()`),
not JavaScript instance of `ContextifyContext`, when we did
`ObjectWrap::Unwrap<ContextifyContext>(data)` in `GlobalPropertyGetter()`.
As a result, we were receiving pointer to a destructed instance after
`ContextifyContext` instance was disposed of.
