### PR TITLE
Upgraded nan to 1.5.0 to support iojs

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     ],
     "dependencies": {
         "bindings" : "*",
-        "nan" : "~1.3.0"
+        "nan" : "~1.5.0"
     },
     "devDependencies": {
         "nodeunit" : ">=0.5.x"


### PR DESCRIPTION
With nan 1.5.0 contextify will compile on iojs. 
All tests passes OK with iojs 1.1.0 and 0.10.36 on Ubuntu.