### PR TITLE
Add node version restraint

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
         "test": "nodeunit test/"
     },
     "engines": {
-        "node": ">=0.4.0"
+        "node": ">=0.4.0 <4.0"
     },
     "licenses": [
         {


### PR DESCRIPTION
This does not compile with node versions 4+.
I am not 100% sure if the syntax of this edit is correct, but there are quite a few 'fails to compile' github issues, that this may have prevented.