### PR TITLE
Add support back for v0.10, added dnt configuration

### DIFF
--- a/.dntrc
+++ b/.dntrc
@@ -1,0 +1,19 @@
+## DNT config file
+## see https://github.com/rvagg/dnt
+
+NODE_VERSIONS="\
+  v0.10.40     \
+  v0.12.7      \
+  v1.8.4       \
+  v2.5.0       \
+  v3.3.0       \
+  v4.2.2       \
+  v5.0.0       \
+"
+OUTPUT_PREFIX="contextify-"
+TEST_CMD="\
+  cd /dnt/ &&                                                    \
+  npm install --nodedir=/usr/src/node &&                         \
+  npm test;                          \
+"
+LOG_OK_CMD="tail -1 | sed 's/.\[1m.\[32mOK: .\[39m.\[22m.* assertions.*/ok/'"

--- a/package.json
+++ b/package.json
@@ -36,8 +36,8 @@
         }
     ],
     "dependencies": {
-        "bindings" : "*",
-        "nan" : "^2.1.0"
+        "bindings": "^1.2.1",
+        "nan": "^2.1.0"
     },
     "devDependencies": {
         "nodeunit" : ">=0.5.x"


### PR DESCRIPTION
Adding on the work in #190 and #192 but adds back support for v0.10 which broke with those changes. Tests all pass now, I added a [dnt](https://github.com/rvagg/dnt/) configuration file which can be used to test this across versions:

```
$ dnt
node@v0.10.40: PASS wrote output to /tmp/contextify-dnt-v0.10.40.out
node@v0.12.7 : PASS wrote output to /tmp/contextify-dnt-v0.12.7.out
node@v1.8.4  : PASS wrote output to /tmp/contextify-dnt-v1.8.4.out
node@v2.5.0  : PASS wrote output to /tmp/contextify-dnt-v2.5.0.out
node@v3.3.0  : PASS wrote output to /tmp/contextify-dnt-v3.3.0.out
node@v4.2.2  : PASS wrote output to /tmp/contextify-dnt-v4.2.2.out
node@v5.0.0  : PASS wrote output to /tmp/contextify-dnt-v5.0.0.out
Took 31s to run        7 versions of Node
```

/cc @idoby 