### PR TITLE
Add license field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "engines": {
         "node": ">=4.0.0"
     },
+    "license": "MIT",
     "licenses": [
         {
             "type": "MIT",


### PR DESCRIPTION
The following warning.

```
npm WARN contextify@0.1.15 No license field.
```