### PR TITLE
 Drop support for Node.js versions <= 4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,9 @@ node_js:
   - "10"
   - "8"
   - "6"
+cache:
+  directories:
+    - node_modules
 addons:
   apt:
    sources:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,8 @@
 language: node_js
 node_js:
   - "10"
-  - "9"
   - "8"
   - "6"
-  - "4"
 addons:
   apt:
    sources:

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
         "test": "nodeunit test/"
     },
     "engines": {
-        "node": ">=4.0.0"
+        "node": ">=6.0.0"
     },
     "license": "MIT",
     "licenses": [


### PR DESCRIPTION
https://github.com/nodejs/Release#end-of-life-releases